### PR TITLE
Remove the hard dependency on newrelic 4 and bump patch version

### DIFF
--- a/lib/newrelic-couchbase/version.rb
+++ b/lib/newrelic-couchbase/version.rb
@@ -1,5 +1,5 @@
 module Newrelic
   module Couchbase
-    VERSION = "1.0.0"
+    VERSION = "1.0.1"
   end
 end

--- a/newrelic-couchbase.gemspec
+++ b/newrelic-couchbase.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'couchbase', '~> 1'
-  gem.add_dependency 'newrelic_rpm', '~> 4'
+  gem.add_dependency 'newrelic_rpm', '> 3'
 end


### PR DESCRIPTION
I wanted to upgrade the newrelic agent in TJS and ran into this dependency on `4.x` in this project. 

Ping - @obrie, @geoffreyclark 