### PR TITLE
Oper 6903/couchbase3 updates

### DIFF
--- a/lib/newrelic-couchbase/version.rb
+++ b/lib/newrelic-couchbase/version.rb
@@ -1,5 +1,5 @@
 module Newrelic
   module Couchbase
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end

--- a/newrelic-couchbase.gemspec
+++ b/newrelic-couchbase.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'couchbase', '~> 1'
+  gem.add_dependency 'couchbase', '>= 1'
   gem.add_dependency 'newrelic_rpm', '> 3'
 end


### PR DESCRIPTION
https://jira.unity3d.com/browse/OPER-6903

@obrie @Tapjoy/eng-group-ops 

Related: https://github.com/Tapjoy/tapjoyserver/pull/23683

We are in the process of updating the Production AMI + Runtime environment to an Ubuntu Jammy based image. The perviously used couchbase libraries are not available on Jammy, which will require us to move to a Couchbase v3 based client.

Cutting an updated version of newrelic-couchbase in order to be able to satisfy the requirements to update the TJS PRs gem bundle for couchbase 3. 

Verification plan:

[ ] Add updated gem to TJS. bundle
[ ] Push updated code to isolated test node in production to ensure couchbase traces are reporting properly in NewRelic 