### PR TITLE
[NPE] Use bucket names

### DIFF
--- a/lib/newrelic-couchbase/instrumentation/collection.rb
+++ b/lib/newrelic-couchbase/instrumentation/collection.rb
@@ -26,9 +26,9 @@ module NewRelic
           end
         end
 
-        def get_all_with_newrelic(*args, &blk)
-          NewRelic::Agent::Datastores.wrap('Couchbase', 'get_all', bucket_name, get_upsert_callback(args.inspect)) do
-            get_all_without_newrelic(*args, &blk)
+        def get_multi_with_newrelic(*args, &blk)
+          NewRelic::Agent::Datastores.wrap('Couchbase', 'get_multi', bucket_name, get_upsert_callback(args.inspect)) do
+            get_multi_without_newrelic(*args, &blk)
           end
         end
       end
@@ -45,8 +45,8 @@ end
   alias_method :get, :get_with_newrelic
   alias_method :get_and_touch_without_newrelic, :get_and_touch
   alias_method :get_and_touch, :get_and_touch_with_newrelic
-  alias_method :get_all_without_newrelic, :get_all
-  alias_method :get_all, :get_all_with_newrelic
+  alias_method :get_multi_without_newrelic, :get_multi
+  alias_method :get_multi, :get_multi_with_newrelic
 
   [
     :binary,
@@ -54,7 +54,6 @@ end
     :get_all_replicas,
     :get_and_lock,
     :get_any_replica,
-    :get_multi,
     :insert,
     :lookup_in,
     :lookup_in_all_replicas,

--- a/lib/newrelic-couchbase/instrumentation/collection.rb
+++ b/lib/newrelic-couchbase/instrumentation/collection.rb
@@ -9,14 +9,26 @@ module NewRelic
         end
 
         def upsert_with_newrelic(*args, &blk)
-          NewRelic::Agent::Datastores.wrap('Couchbase', 'upsert', name, get_upsert_callback(args.inspect)) do
+          NewRelic::Agent::Datastores.wrap('Couchbase', 'upsert', bucket_name, get_upsert_callback(args.inspect)) do
             upsert_without_newrelic(*args, &blk)
           end
         end
 
         def get_with_newrelic(*args, &blk)
-          NewRelic::Agent::Datastores.wrap('Couchbase', 'get', name, get_upsert_callback(args.inspect)) do
+          NewRelic::Agent::Datastores.wrap('Couchbase', 'get', bucket_name, get_upsert_callback(args.inspect)) do
             get_without_newrelic(*args, &blk)
+          end
+        end
+
+        def get_and_touch_with_newrelic(*args, &blk)
+          NewRelic::Agent::Datastores.wrap('Couchbase', 'get_and_touch', bucket_name, get_upsert_callback(args.inspect)) do
+            get_and_touch_without_newrelic(*args, &blk)
+          end
+        end
+
+        def get_all_with_newrelic(*args, &blk)
+          NewRelic::Agent::Datastores.wrap('Couchbase', 'get_all', bucket_name, get_upsert_callback(args.inspect)) do
+            get_all_without_newrelic(*args, &blk)
           end
         end
       end
@@ -31,14 +43,16 @@ end
   alias_method :upsert, :upsert_with_newrelic
   alias_method :get_without_newrelic, :get
   alias_method :get, :get_with_newrelic
+  alias_method :get_and_touch_without_newrelic, :get_and_touch
+  alias_method :get_and_touch, :get_and_touch_with_newrelic
+  alias_method :get_all_without_newrelic, :get_all
+  alias_method :get_all, :get_all_with_newrelic
 
   [
     :binary,
     :exists,
-    :get_all,
     :get_all_replicas,
     :get_and_lock,
-    :get_and_touch,
     :get_any_replica,
     :get_multi,
     :insert,

--- a/lib/newrelic-couchbase/version.rb
+++ b/lib/newrelic-couchbase/version.rb
@@ -1,5 +1,5 @@
 module Newrelic
   module Couchbase
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
   end
 end


### PR DESCRIPTION
Couchbase now uses collections so we need to use `bucket_name` to get meaningful data in NR.