### PR TITLE
[OW-4826] Prep for newrelic_rpm upgrade

### DIFF
--- a/lib/newrelic-couchbase/instrumentation/collection.rb
+++ b/lib/newrelic-couchbase/instrumentation/collection.rb
@@ -4,7 +4,7 @@ module NewRelic
       module Couchbase
         def get_upsert_callback(statement)
           Proc.new do |result, scoped_metric, elapsed|
-            NewRelic::Agent::Datastores.notice_statement(statement, elapsed)
+            NewRelic::Agent::Datastores.notice_statement(statement)
           end
         end
 

--- a/lib/newrelic-couchbase/version.rb
+++ b/lib/newrelic-couchbase/version.rb
@@ -1,5 +1,5 @@
 module Newrelic
   module Couchbase
-    VERSION = "3.1.0"
+    VERSION = "3.1.1"
   end
 end

--- a/newrelic-couchbase.gemspec
+++ b/newrelic-couchbase.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency 'couchbase', '~> 3'
-  gem.add_dependency 'newrelic_rpm', '>= 4.5'
+  gem.add_dependency 'newrelic_rpm', '>= 9.24'
 end


### PR DESCRIPTION
## Description
JIRA [🎫](https://jira.unity3d.com/browse/OW-4826)

The newrelic_rpm 9.24 has warn message which filled up the newrelic log.

```The NewRelic::Agent::Datastores.notice_statement method is changing. In a future major version, the elapsed argument will be removed. The elapsed value is now based on the current segment when the notice_statement method was called.```

This PR adjusts the passed parameter of `NewRelic::Agent::Datastores.notice_statement` as preliminary of `newrelic_rpm` gem upgrade.

From the change log

> [!IMPORTANT]
> Breaking Change: Remove unused arguments from various NewRelic::Agent::Datastores APIs
> The following APIs from the NewRelic::Agent::Datastores class have had method arguments removed:
> 1. NewRelic::Agent::Datastores.notice_sql, previously had three positional arguments, query, scoped_metric and elapsed. Now, it only has query.
> 2. NewRelic::Agent::Datastores.notice_statement, previously had two positional arguments query and elapsed. Now it only has query.
> 3. NewRelic::Agent::Datastores.wrap requires a proc. Previously the proc received three arguments: the result of the yield, the most specific scoped metric name, and the elapsed time of the call. Now, it only receives one: the result of the yield.

The `v10.2.0` removed this warning.